### PR TITLE
Fixed skipping of tiles from other tilesets

### DIFF
--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -128,9 +128,11 @@ class GodotTilemapExporter {
                         // noinspection JSUnresolvedFunction
                         tileset = tile.tileset;
                         tilesetColumns = this.getTilesetColumns(tileset);
-                    } else if (!hasWarned && tileset !== tile.tileset) {
-                        tiled.warn(`Multiple tilesets used on layer "${layer.name}", only exporting tiles from "${tileset.name}"`);
-                        hasWarned = true;
+                    } else if (tileset !== tile.tileset) {
+                        if (!hasWarned) {
+                            tiled.warn(`Multiple tilesets used on layer "${layer.name}", only exporting tiles from "${tileset.name}"`);
+                            hasWarned = true;
+                        }
                         continue;
                     }
 


### PR DESCRIPTION
Let's do as claimed in the warning: only export tiles from the first encountered tileset.

Fixing up #1.