### PR TITLE
Take into account tile spacing (padding between tiles)

### DIFF
--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -195,7 +195,7 @@ class GodotTilemapExporter {
      **/
     getTilesetColumns(tileset) {
         // noinspection JSUnresolvedVariable
-        const imageWidth = tileset.imageWidth + tileset.tileSpacing - (tileset.margin * 2)
+        const imageWidth = tileset.imageWidth + tileset.tileSpacing - tileset.margin
         const tileWidth = tileset.tileWidth + tileset.tileSpacing
         const calculatedColumnCount = imageWidth / tileWidth
         // Tiled ignores "partial" tiles (extra unaccounted for pixels in the image),

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -188,12 +188,19 @@ class GodotTilemapExporter {
 
     /**
      * Tileset should expose columns ... but didn't at the moment so we
-     * calculate them base on the image width and tileWidth
-     * return {number}
+     * calculate them base on the image width and tileWidth.
+     * Takes into account margin (extra space around the image edges) and 
+     * tile spacing (padding between individual tiles).
+     * @returns {number}
      **/
     getTilesetColumns(tileset) {
         // noinspection JSUnresolvedVariable
-        return Math.ceil(tileset.imageWidth / (tileset.tileWidth + tileset.tileSpacing));
+        const imageWidth = tileset.imageWidth + tileset.tileSpacing - (tileset.margin * 2)
+        const tileWidth = tileset.tileWidth + tileset.tileSpacing
+        const calculatedColumnCount = imageWidth / tileWidth
+        // Tiled ignores "partial" tiles (extra unaccounted for pixels in the image),
+        // so we need to return as Math.floor to avoid throwing off the tile indices.
+        return Math.floor(calculatedColumnCount);
     }
 
     /**

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -193,7 +193,7 @@ class GodotTilemapExporter {
      **/
     getTilesetColumns(tileset) {
         // noinspection JSUnresolvedVariable
-        return Math.floor(tileset.imageWidth / tileset.tileWidth);
+        return Math.ceil(tileset.imageWidth / (tileset.tileWidth + tileset.tileSpacing));
     }
 
     /**

--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -117,7 +117,7 @@ ${this.shapesResources}[resource]
 0/texture = ExtResource( 1 )
 0/tex_offset = Vector2( 0, 0 )
 0/modulate = Color( 1, 1, 1, 1 )
-0/region = Rect2( 0, 0, ${this.tileset.imageWidth}, ${this.tileset.imageHeight} )
+0/region = Rect2( ${this.tileset.margin}, ${this.tileset.margin}, ${this.tileset.imageWidth}, ${this.tileset.imageHeight} )
 0/tile_mode = 2
 0/autotile/icon_coordinate = Vector2( 0, 0 )
 0/autotile/tile_size = Vector2( ${this.tileset.tileWidth}, ${this.tileset.tileHeight} )

--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -121,7 +121,7 @@ ${this.shapesResources}[resource]
 0/tile_mode = 2
 0/autotile/icon_coordinate = Vector2( 0, 0 )
 0/autotile/tile_size = Vector2( ${this.tileset.tileWidth}, ${this.tileset.tileHeight} )
-0/autotile/spacing = 0
+0/autotile/spacing = ${this.tileset.tileSpacing}
 0/autotile/occluder_map = [  ]
 0/autotile/navpoly_map = [  ]
 0/autotile/priority_map = [  ]


### PR DESCRIPTION
I noticed that exports didn't seem to be working quite right when trying to export maps with tilesets that have a tile spacing other than zero -- for example, this Kenney Roguelike tile set which has 1px between each tile:
https://opengameart.org/content/roguelikerpg-pack-1700-tiles

I've tested this change with a few example tilemaps and it seems to address the issue and work as expected, though would appreciate any additional testing or feedback in case I've missed anything.

PS: thanks for taking the time to create and share this super useful plugin! :)