### PR TITLE
Add Godot groups on layers and support for Area2D and Node2D nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,24 @@ Legend: ticked = done, unticked = to do
 
 \* The Godot tileset editor supports only Rectangle and Polygon. That's Tiled are supported and are converted to polygons in Godot.
 
+## Supported entity types
+
+Creating entities with these types will result in specific nodes to be created :
+
+- type `Area`
+
+  Creates an `Area2D` node in the scene, containing a `CollisionShape2D` with the rectangle set in the tiled map.
+
+  You can add `collision_layer` and `collision_mask` integer custom properties to set these properties for Godot.
+
+- type `Node2D`
+
+  Creates an empty `Node2D` at the specified position. Can be useful for defining spawn points for example.
+
+If present, the `group` custom string property will add the generated entity to the specified Godot scene group.
+
 ## Long term plans
+
 I'm making a 2D platformer and I'm gonna focus on these needs for now.
 Generally, I would like to support everything Tiled offers because it's a very good level editor.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Creating entities with these types will result in specific nodes to be created :
 
   Creates an empty `Node2D` at the specified position. Can be useful for defining spawn points for example.
 
-If present, the `group` custom string property will add the generated entity to the specified Godot scene group.
+If present, the `groups` custom string property will add the generated entity to the specified Godot scene groups. Accepts multiple groups via comma separation: `Group1, Group2`.
 
 ## Long term plans
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Legend: ticked = done, unticked = to do
 
 Creating entities with these types will result in specific nodes to be created :
 
-- type `Area`
+- type `Area2D`
 
   Creates an `Area2D` node in the scene, containing a `CollisionShape2D` with the rectangle set in the tiled map.
 

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -145,7 +145,7 @@ class GodotTilemapExporter {
                             region_enabled: true,
                             region_rect: `Rect2( ${tileOffset.x}, ${tileOffset.y}, ${object.tile.width}, ${object.tile.height} )`
                         });
-                    } else if (object.type == "Area" && object.width && object.height) {
+                    } else if (object.type == "Area2D" && object.width && object.height) {
                         // Creates an Area2D node with a rectangle shape inside
                         // Does not support rotation
                         const width = object.width / 2;

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -100,7 +100,7 @@ class GodotTilemapExporter {
                     if (!ld.isEmpty) {
                         const tileMapName = idx === 0 ? layer.name || "TileMap " + i : ld.tileset.name || "TileMap " + i + "_" + idx;
                         this.mapLayerToTileset(layer.name, ld.tilesetID);
-                        this.tileMapsString += this.getTileMapTemplate(tileMapName, ld.tilesetID, ld.poolIntArrayString, ld.parent, layer.map.tileWidth, layer.map.tileHeight, layer.property("group"));
+                        this.tileMapsString += this.getTileMapTemplate(tileMapName, ld.tilesetID, ld.poolIntArrayString, ld.parent, layer.map.tileWidth, layer.map.tileHeight, layer.property("groups"));
                     }
                 }
             } else if (layer.isObjectLayer) {
@@ -109,12 +109,12 @@ class GodotTilemapExporter {
                     name: layer.name,
                     type: "Node2D",
                     parent: ".",
-                    groups: singleDefinedItemToArray(layer.property("group"))
+                    groups: splitCommaSeparated(layer.property("groups"))
                 });
 
                 // add entities
                 for (const object of layer.objects) {
-                    const groups = singleDefinedItemToArray(object.property("group"));
+                    const groups = splitCommaSeparated(object.property("groups"));
 
                     if (object.tile) {
                         let tilesetsIndexKey = object.tile.tileset.name + "_Image";
@@ -446,12 +446,8 @@ ${this.tileMapsString}
      * Template for a tilemap node
      * @returns {string}
      */
-    getTileMapTemplate(tileMapName, tilesetID, poolIntArrayString, parent = ".", tileWidth = 16, tileHeight = 16, group = undefined) {
-        let groups = undefined;
-        if (group) {
-            groups = [group];
-        }
-
+    getTileMapTemplate(tileMapName, tilesetID, poolIntArrayString, parent = ".", tileWidth = 16, tileHeight = 16, groups = undefined) {
+        groups = splitCommaSeparated(groups);
         return stringifyNode({
             name: tileMapName,
             type: "TileMap",

--- a/utils.js
+++ b/utils.js
@@ -47,3 +47,75 @@ function getTilesetColumns(tileset) {
   // so we need to return as Math.floor to avoid throwing off the tile indices.
   return Math.floor(calculatedColumnCount);
 }
+
+/**
+ * returns undefined if undefined is passed in,
+ * returns an array with the `single` item inside otherwise 
+ */
+function singleDefinedItemToArray(single) {
+  if (!single) {
+    return undefined;
+  }
+  return [single];
+}
+
+/**
+ * Removes any undefined value with its key from an object
+ * @param {object} obj 
+ */
+function removeUndefined(obj) {
+  Object.keys(obj).forEach(key => obj[key] === undefined && delete obj[key])
+}
+
+
+/**
+ * Translates key values defining a godot scene node to the expected TSCN format output
+ * Passed keys must be strings. Values can be arrays (e.g. for groups)
+ * 
+ * @param {object} nodeProperties pair key/values for the "node" properties
+ * @param {object} contentProperties pair key/values for the content properties
+ * @return {string} TSCN scene node like so :
+ *         ```
+ *          [node key="value"]
+ *          content_key = AnyValue
+ *         ``` 
+ */
+function stringifyNode(nodeProperties, contentProperties = {}) {
+  // remove undefined values from objects
+  removeUndefined(nodeProperties);
+  removeUndefined(contentProperties);
+
+  let str = '\n';
+  str += '[node';
+  for (const [key, value] of Object.entries(nodeProperties)) {
+    str += ' ' + this.stringifyKeyValue(key, value, true, false);
+  }
+  str += ']\n';
+  for (const [key, value] of Object.entries(contentProperties)) {
+    str += this.stringifyKeyValue(key, value, false, true) + '\n';
+  }
+
+  return str;
+}
+
+/**
+ * Processes a key/value pair for a TSCN node
+ * 
+ * @param {string} key 
+ * @param {string|array} value 
+ * @param {bool} quote
+ * @param {bool} spaces 
+ */
+function stringifyKeyValue(key, value, quote, spaces) {
+  // flatten arrays
+  console.log(value);
+  if (Array.isArray(value)) {
+    value = '[\n"' + value.join('","') + '",\n]';
+  } else if (quote) {
+    value = `"${value}"`;
+  }
+  if (!spaces) {
+    return `${key}=${value}`;
+  }
+  return `${key} = ${value}`;
+}

--- a/utils.js
+++ b/utils.js
@@ -49,14 +49,13 @@ function getTilesetColumns(tileset) {
 }
 
 /**
- * returns undefined if undefined is passed in,
- * returns an array with the `single` item inside otherwise 
+ * @param {string} str comma separated items
  */
-function singleDefinedItemToArray(single) {
-  if (!single) {
+function splitCommaSeparated(str) {
+  if (!str) {
     return undefined;
   }
-  return [single];
+  return str.split(',').map(s => s.trim());
 }
 
 /**
@@ -108,7 +107,6 @@ function stringifyNode(nodeProperties, contentProperties = {}) {
  */
 function stringifyKeyValue(key, value, quote, spaces) {
   // flatten arrays
-  console.log(value);
   if (Array.isArray(value)) {
     value = '[\n"' + value.join('","') + '",\n]';
   } else if (quote) {


### PR DESCRIPTION
Hello !

Thanks for making this plugin !

This PR adds support for some Godot features :
- Godot node groups
- Area2D rectangular zones
- Abritrary Node2D entities

I did take some liberty with the code, by refactoring a bit the Godot formatted node creation part to make it more automated, I did not really like the randomness of creating nodes by directly pasting lines in javascript, so I made a method like so :

```js
stringifyNode({
    name: object.name,
    type: "Area2D",
    parent: layer.name,
    groups: groups
}, {
    collision_layer: object.property("collision_layer"),
    collision_mask: object.property("collision_mask")
});
```
Will generate (example with random data):

```
[node name="SpawnArea" type="Area2D" parent="MapName" groups=[
"Spawns",
]]
collision_layer = 1024
```

It makes defining nodes easier and more flexible in my opinion, since it can automatically ignore `undefined` properties, which makes it simpler to include custom user properties from Tiled.

(this is also my first PR so let me know if I did something wrong)

## Usage

### Godot Groups

Go to any Layer or entity in Tiled, and add a custom string property `group`. The value will be the Godot group for the generated node. This only supports one group as I do not have the use for multiple groups and don't know yet how to best represent multiple groups from Tiled.

### Area2D

Go to an entity layer and create a Rectangle. The entity type must be set to `Area`.

This will generate an Area2D with a rectangular collision shape. Rotation is not supported.

Supported custom properties for the Area2D are:

- `collision_layer` (int)
- `collision_mask` (int)

### Node2D

Same thing, but with a point maker and the `Node2D` type (will work with any shape though since it only uses the x and y values).

![image](https://user-images.githubusercontent.com/2473314/102392409-4b5f7e00-3fd7-11eb-8eea-9152733ed3bd.png)

generates this :  

![image](https://user-images.githubusercontent.com/2473314/102392495-6a5e1000-3fd7-11eb-9f1b-d8a8c96b8406.png)


Of course this supports the `group` custom property.

---

Thanks for reading this, let me know for anything!
If you don't want to merge this, no problem, I'll just continue adding features on my fork, but I figured it could help this project!
