### PR TITLE
Fixed export error on "Area2D" objects

### DIFF
--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -51,9 +51,10 @@ class GodotTilemapExporter {
 
 [sub_resource type="${type}" id=${id}]
 `;
-        removeUndefined(contentProperties);
         for (const [key, value] of Object.entries(contentProperties)) {
-            this.subResourcesString += stringifyKeyValue(key, value, false, true) + '\n';
+            if (value !== undefined) {
+                this.subResourcesString += stringifyKeyValue(key, value, false, true) + '\n';
+            }
         }
 
         return id;


### PR DESCRIPTION
I had removed removeUndefined in 6d84e4df8c3a44e13bedbf078f2e5ec5cd7ec, but hadn't noticed this usage.

Closes #28.