### PR TITLE
Add support for opacity, offset, and visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ More about my struggles can be read in Tiled Forum or Godot reddit. Check the Co
 - [x] Export TileSets from Tiled standalone tileset files
 - [x] Orthogonal maps
 - [ ] Isometric, staggered, and hexagonal maps
-- [ ] Export visibility and opacity from layers
+- [x] Export visibility and opacity from layers
 - [x] Export collision shapes<sup>*</sup>
 - [ ] Export occluder shapes<sup>*</sup>
 - [x] Export navigation shapes<sup>*</sup>

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -62,7 +62,7 @@ class GodotTilemapExporter {
 
     /**
      * Generate a string with all tilesets in the map.
-     * Godot allows only one tileset per tilemap so if you use more than one tileset per layer it's n ot going to work.
+     * Godot allows only one tileset per tilemap so if you use more than one tileset per layer it's not going to work.
      * Godot supports several image textures per tileset but Tiled Editor doesn't.
      * Tiled editor supports only one tile
      * sprite image per tileset.

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -452,6 +452,8 @@ ${this.tileMapsString}
     getTileMapTemplate(tileMapName, mode, tilesetID, poolIntArrayString, layer, parent = ".") {
         const tileWidth = layer.map.tileWidth === undefined ? 16 : layer.map.tileWidth;
         const tileHeight = layer.map.tileHeight === undefined ? 16 : layer.map.tileHeight;
+        const offsetHorizontal = layer.offset.x === undefined ? 0 : layer.offset.x;
+        const offsetVertical = layer.offset.y === undefined ? 0 : layer.offset.y;
         const groups = splitCommaSeparated(layer.property("groups"));
         const zIndex = parseInt(layer.properties()['z_index'], 10);
         return stringifyNode({
@@ -460,6 +462,7 @@ ${this.tileMapsString}
             parent: parent,
             groups: groups
         }, {
+            position: `Vector2( ${offsetHorizontal}, ${offsetVertical} )`,
             tile_set: `ExtResource( ${tilesetID} )`,
             cell_size: `Vector2( ${tileWidth}, ${tileHeight} )`,
             cell_custom_transform: `Transform2D( 16, 0, 0, 16, 0, 0 )`,

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -455,6 +455,7 @@ ${this.tileMapsString}
         const offsetHorizontal = layer.offset.x === undefined ? 0 : layer.offset.x;
         const offsetVertical = layer.offset.y === undefined ? 0 : layer.offset.y;
         const visible = layer.visible === undefined ? true : layer.visible;
+        const opacity = layer.opacity === undefined ? 1 : layer.opacity;
         const groups = splitCommaSeparated(layer.property("groups"));
         const zIndex = parseInt(layer.properties()['z_index'], 10);
         return stringifyNode({
@@ -464,6 +465,7 @@ ${this.tileMapsString}
             groups: groups
         }, {
             visible: visible,
+            modulate: `Color( 1, 1, 1, ${opacity} )`,
             position: `Vector2( ${offsetHorizontal}, ${offsetVertical} )`,
             tile_set: `ExtResource( ${tilesetID} )`,
             cell_size: `Vector2( ${tileWidth}, ${tileHeight} )`,

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -450,12 +450,6 @@ ${this.tileMapsString}
      * @returns {string}
      */
     getTileMapTemplate(tileMapName, mode, tilesetID, poolIntArrayString, layer, parent = ".") {
-        const tileWidth = layer.map.tileWidth === undefined ? 16 : layer.map.tileWidth;
-        const tileHeight = layer.map.tileHeight === undefined ? 16 : layer.map.tileHeight;
-        const offsetHorizontal = layer.offset.x === undefined ? 0 : layer.offset.x;
-        const offsetVertical = layer.offset.y === undefined ? 0 : layer.offset.y;
-        const visible = layer.visible === undefined ? true : layer.visible;
-        const opacity = layer.opacity === undefined ? 1 : layer.opacity;
         const groups = splitCommaSeparated(layer.property("groups"));
         const zIndex = parseInt(layer.properties()['z_index'], 10);
         return stringifyNode({
@@ -464,11 +458,11 @@ ${this.tileMapsString}
             parent: parent,
             groups: groups
         }, {
-            visible: visible,
-            modulate: `Color( 1, 1, 1, ${opacity} )`,
-            position: `Vector2( ${offsetHorizontal}, ${offsetVertical} )`,
+            visible: layer.visible,
+            modulate: `Color( 1, 1, 1, ${layer.opacity} )`,
+            position: `Vector2( ${layer.offset.x}, ${layer.offset.y} )`,
             tile_set: `ExtResource( ${tilesetID} )`,
-            cell_size: `Vector2( ${tileWidth}, ${tileHeight} )`,
+            cell_size: `Vector2( ${layer.map.tileWidth}, ${layer.map.tileHeight} )`,
             cell_custom_transform: `Transform2D( 16, 0, 0, 16, 0, 0 )`,
             format: 1,
             mode: mode,

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -454,6 +454,7 @@ ${this.tileMapsString}
         const tileHeight = layer.map.tileHeight === undefined ? 16 : layer.map.tileHeight;
         const offsetHorizontal = layer.offset.x === undefined ? 0 : layer.offset.x;
         const offsetVertical = layer.offset.y === undefined ? 0 : layer.offset.y;
+        const visible = layer.visible === undefined ? true : layer.visible;
         const groups = splitCommaSeparated(layer.property("groups"));
         const zIndex = parseInt(layer.properties()['z_index'], 10);
         return stringifyNode({
@@ -462,6 +463,7 @@ ${this.tileMapsString}
             parent: parent,
             groups: groups
         }, {
+            visible: visible,
             position: `Vector2( ${offsetHorizontal}, ${offsetVertical} )`,
             tile_set: `ExtResource( ${tilesetID} )`,
             cell_size: `Vector2( ${tileWidth}, ${tileHeight} )`,


### PR DESCRIPTION
I started using this excellent tool for exporting Tiled maps to Godot and noticed a few things missing for my use case. Namely, I needed support for a few properties under Tile Layer. I've gone ahead and created the appropriate mappings.

- Visible -> visible boolean
- Opacity -> modulate.alpha
- Horizontal Offset -> position.x
- Vertical Offset -> position.y

I noticed visibility and opacity were already listed in the TODO features list, so I checked it off. I've tested with my project and everything seems to work as expected.