### PR TITLE
Updates for GroupLayer and custom properties

### DIFF
--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -63,7 +63,7 @@ class GodotTilemapExporter {
 
     /**
      * Generate a string with all tilesets in the map.
-     * Godot allows only one tileset per tilemap so if you use more than one tileset per layer it's n ot going to work.
+     * Godot allows only one tileset per tilemap so if you use more than one tileset per layer it's not going to work.
      * Godot supports several image textures per tileset but Tiled Editor doesn't.
      * Tiled editor supports only one tile
      * sprite image per tileset.

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -5,7 +5,6 @@ class GodotTilemapExporter {
     constructor(map, fileName) {
         this.map = map;
         this.fileName = fileName;
-        this.filePath = fileName.substring(0, fileName.lastIndexOf("/"));
         // noinspection JSUnresolvedFunction
         this.projectRoot = getResPath(this.map.property("projectRoot"), fileName);
         this.tileOffset = 65536;
@@ -78,7 +77,7 @@ class GodotTilemapExporter {
             this.extResourceId = index + 1;
             this.tilesetsIndex.set(tileset.name, this.extResourceId);
             // noinspection JSUnresolvedVariable
-            let tilesetPath = tileset.asset.fileName.replace(this.filePath, this.projectRoot).replace('.tsx', '.tres');
+            let tilesetPath = tileset.asset.fileName.replace(this.projectRoot, "").replace('.tsx', '.tres');
             this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "TileSet");
         }
 
@@ -131,7 +130,7 @@ class GodotTilemapExporter {
                         this.extResourceId = this.extResourceId + 1;
                         textureResourceId = this.extResourceId;
                         this.tilesetsIndex.set(tilesetsIndexKey, this.extResourceId);
-                        let tilesetPath = this.projectRoot;
+                        let tilesetPath = object.tile.tileset.image.replace(this.projectRoot, "");
                         this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "Texture");
                     } else {
                         textureResourceId = this.tilesetsIndex.get(tilesetsIndexKey);

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -217,7 +217,7 @@ class GodotTilemapExporter {
                                 position: `Vector2( ${object.x}, ${object.y} )`
                             }
                         ),
-                        this.meta_properties(layer.properties())
+                        this.meta_properties(object.properties())
                     );
                 }
             }

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -5,7 +5,7 @@ class GodotTilemapExporter {
     constructor(map, fileName) {
         this.map = map;
         this.fileName = fileName;
-		this.filePath = fileName.substring(0, fileName.lastIndexOf("/"));
+        this.filePath = fileName.substring(0, fileName.lastIndexOf("/"));
         // noinspection JSUnresolvedFunction
         this.projectRoot = getResPath(this.map.property("projectRoot"), fileName);
         this.tileOffset = 65536;
@@ -95,176 +95,176 @@ class GodotTilemapExporter {
 
             // noinspection JSUnresolvedFunction
             let layer = this.map.layerAt(i);
-			this.handleLayer(layer, mode, ".");
-		}
+            this.handleLayer(layer, mode, ".");
+        }
     }
 
-	handleLayer(layer, mode, layer_parent) {
-	    // noinspection JSUnresolvedVariable
-		if (layer.isTileLayer) {
-			const layerData = this.getLayerData(layer);
-			for (let idx = 0; idx < layerData.length; idx++) {
-				const ld = layerData[idx];
-				if (!ld.isEmpty) {
-					const tileMapName = idx === 0 ? layer.name || "TileMap " + i : ld.tileset.name || "TileMap " + i + "_" + idx;
-					this.mapLayerToTileset(layer.name, ld.tilesetID);
-					this.tileMapsString += this.getTileMapTemplate(tileMapName, mode, ld.tilesetID, ld.poolIntArrayString, layer, layer_parent);
-				}
-			}
-		} else if (layer.isObjectLayer) {
-			// create layer
-			this.tileMapsString += stringifyNode({
-				name: layer.name,
-				type: "Node2D",
-				parent: layer_parent,
-				groups: splitCommaSeparated(layer.property("groups"))
-			});
+    handleLayer(layer, mode, layer_parent) {
+        // noinspection JSUnresolvedVariable
+        if (layer.isTileLayer) {
+            const layerData = this.getLayerData(layer);
+            for (let idx = 0; idx < layerData.length; idx++) {
+                const ld = layerData[idx];
+                if (!ld.isEmpty) {
+                    const tileMapName = idx === 0 ? layer.name || "TileMap " + i : ld.tileset.name || "TileMap " + i + "_" + idx;
+                    this.mapLayerToTileset(layer.name, ld.tilesetID);
+                    this.tileMapsString += this.getTileMapTemplate(tileMapName, mode, ld.tilesetID, ld.poolIntArrayString, layer, layer_parent);
+                }
+            }
+        } else if (layer.isObjectLayer) {
+            // create layer
+            this.tileMapsString += stringifyNode({
+                name: layer.name,
+                type: "Node2D",
+                parent: layer_parent,
+                groups: splitCommaSeparated(layer.property("groups"))
+            });
 
-			// add entities
-			for (const object of layer.objects) {
-				const groups = splitCommaSeparated(object.property("groups"));
+            // add entities
+            for (const object of layer.objects) {
+                const groups = splitCommaSeparated(object.property("groups"));
 
-				if (object.tile) {
-					let tilesetsIndexKey = object.tile.tileset.name + "_Image";
-					let textureResourceId = 0;
-					if (!this.tilesetsIndex.get(tilesetsIndexKey)) {
-						this.extResourceId = this.extResourceId + 1;
-						textureResourceId = this.extResourceId;
-						this.tilesetsIndex.set(tilesetsIndexKey, this.extResourceId);
-						let tilesetPath = this.projectRoot;
-						this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "Texture");
-					} else {
-						textureResourceId = this.tilesetsIndex.get(tilesetsIndexKey);
-					}
+                if (object.tile) {
+                    let tilesetsIndexKey = object.tile.tileset.name + "_Image";
+                    let textureResourceId = 0;
+                    if (!this.tilesetsIndex.get(tilesetsIndexKey)) {
+                        this.extResourceId = this.extResourceId + 1;
+                        textureResourceId = this.extResourceId;
+                        this.tilesetsIndex.set(tilesetsIndexKey, this.extResourceId);
+                        let tilesetPath = this.projectRoot;
+                        this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "Texture");
+                    } else {
+                        textureResourceId = this.tilesetsIndex.get(tilesetsIndexKey);
+                    }
 
-					let tileOffset = this.getTileOffset(object.tile.tileset, object.tile.id);
+                    let tileOffset = this.getTileOffset(object.tile.tileset, object.tile.id);
 
-					// Account for anchoring in Godot (corner vs. middle):
-					let objectPositionX = object.x + (object.tile.width / 2);
-					let objectPositionY = object.y - (object.tile.height / 2);
+                    // Account for anchoring in Godot (corner vs. middle):
+                    let objectPositionX = object.x + (object.tile.width / 2);
+                    let objectPositionY = object.y - (object.tile.height / 2);
 
-					this.tileMapsString += stringifyNode(
-						{
-							name: object.name,
-							type: "Sprite",
-							parent: layer_parent + "/" + layer.name
-						}, 
-						this.merge_properties(
-							object.properties(),
-							{
-								position: `Vector2( ${objectPositionX}, ${objectPositionY} )`,
-								texture: `ExtResource( ${textureResourceId} )`,
-								region_enabled: true,
-								region_rect: `Rect2( ${tileOffset.x}, ${tileOffset.y}, ${object.tile.width}, ${object.tile.height} )`
-							}
-						),
-						this.meta_properties(layer.properties())
-					);
-				} else if (object.type == "Area2D" && object.width && object.height) {
-					// Creates an Area2D node with a rectangle shape inside
-					// Does not support rotation
-					const width = object.width / 2;
-					const height = object.height / 2;
-					const objectPositionX = object.x + width;
-					const objectPositionY = object.y + height;
+                    this.tileMapsString += stringifyNode(
+                        {
+                            name: object.name,
+                            type: "Sprite",
+                            parent: layer_parent + "/" + layer.name
+                        }, 
+                        this.merge_properties(
+                            object.properties(),
+                            {
+                                position: `Vector2( ${objectPositionX}, ${objectPositionY} )`,
+                                texture: `ExtResource( ${textureResourceId} )`,
+                                region_enabled: true,
+                                region_rect: `Rect2( ${tileOffset.x}, ${tileOffset.y}, ${object.tile.width}, ${object.tile.height} )`
+                            }
+                        ),
+                        this.meta_properties(layer.properties())
+                    );
+                } else if (object.type == "Area2D" && object.width && object.height) {
+                    // Creates an Area2D node with a rectangle shape inside
+                    // Does not support rotation
+                    const width = object.width / 2;
+                    const height = object.height / 2;
+                    const objectPositionX = object.x + width;
+                    const objectPositionY = object.y + height;
 
-					this.tileMapsString += stringifyNode(
-						{
-							name: object.name,
-							type: "Area2D",
-							parent:  layer_parent + "/" + layer.name,
-							groups: groups
-						}, 
-						this.merge_properties(
-							object.properties(),
-							{
-								collision_layer: object.property("collision_layer"),
-								collision_mask: object.property("collision_mask")
-							}
-						),
-						this.meta_properties(layer.properties())
-					);
+                    this.tileMapsString += stringifyNode(
+                        {
+                            name: object.name,
+                            type: "Area2D",
+                            parent:  layer_parent + "/" + layer.name,
+                            groups: groups
+                        }, 
+                        this.merge_properties(
+                            object.properties(),
+                            {
+                                collision_layer: object.property("collision_layer"),
+                                collision_mask: object.property("collision_mask")
+                            }
+                        ),
+                        this.meta_properties(layer.properties())
+                    );
 
-					const shapeId = this.addSubResource("RectangleShape2D", {
-						extents: `Vector2( ${width}, ${height} )`
-					});
-					this.tileMapsString += stringifyNode(
-						{
-							name: "CollisionShape2D",
-							type: "CollisionShape2D",
-							parent: `${layer_parent}/${layer.name}/${object.name}`
-						}, 
-						this.merge_properties(
-							object.properties(),
-							{
-								shape: `SubResource( ${shapeId} )`,
-								position: `Vector2( ${objectPositionX}, ${objectPositionY} )`,
-							}
-						),
-						this.meta_properties(layer.properties())
-					);
-				} else if (object.type == "Node2D") {
-					this.tileMapsString += stringifyNode(
-						{
-							name: object.name,
-							type: "Node2D",
-							parent: layer_parent + "/" + layer.name,
-							groups: groups
-						},
-						this.merge_properties(
-							object.properties(), 
-							{
-								position: `Vector2( ${object.x}, ${object.y} )`
-							}
-						),
-						this.meta_properties(layer.properties())
-					);
-				}
-			}
-		} else if (layer.isGroupLayer) {
-			var node_type = layer.property("godot:type") || "Node2D";
-			this.tileMapsString += stringifyNode(
-				{
-					name: layer.name,
-					type: node_type,
-					parent: layer_parent,
-					groups: splitCommaSeparated(layer.property("groups"))
-				}, 
-				this.merge_properties(
-					layer.properties(),
-					{
-					}
-				),
-				this.meta_properties(layer.properties())
-			);
-			for(var i = 0; i < layer.layerCount; ++i) { 
-				this.handleLayer(layer.layers[i], mode, layer_parent + "/" + layer.name);
-			}
-		
-		}
-	}
+                    const shapeId = this.addSubResource("RectangleShape2D", {
+                        extents: `Vector2( ${width}, ${height} )`
+                    });
+                    this.tileMapsString += stringifyNode(
+                        {
+                            name: "CollisionShape2D",
+                            type: "CollisionShape2D",
+                            parent: `${layer_parent}/${layer.name}/${object.name}`
+                        }, 
+                        this.merge_properties(
+                            object.properties(),
+                            {
+                                shape: `SubResource( ${shapeId} )`,
+                                position: `Vector2( ${objectPositionX}, ${objectPositionY} )`,
+                            }
+                        ),
+                        this.meta_properties(layer.properties())
+                    );
+                } else if (object.type == "Node2D") {
+                    this.tileMapsString += stringifyNode(
+                        {
+                            name: object.name,
+                            type: "Node2D",
+                            parent: layer_parent + "/" + layer.name,
+                            groups: groups
+                        },
+                        this.merge_properties(
+                            object.properties(), 
+                            {
+                                position: `Vector2( ${object.x}, ${object.y} )`
+                            }
+                        ),
+                        this.meta_properties(layer.properties())
+                    );
+                }
+            }
+        } else if (layer.isGroupLayer) {
+            var node_type = layer.property("godot:type") || "Node2D";
+            this.tileMapsString += stringifyNode(
+                {
+                    name: layer.name,
+                    type: node_type,
+                    parent: layer_parent,
+                    groups: splitCommaSeparated(layer.property("groups"))
+                }, 
+                this.merge_properties(
+                    layer.properties(),
+                    {
+                    }
+                ),
+                this.meta_properties(layer.properties())
+            );
+            for(var i = 0; i < layer.layerCount; ++i) { 
+                this.handleLayer(layer.layers[i], mode, layer_parent + "/" + layer.name);
+            }
+        
+        }
+    }
 
-	merge_properties(object_props, set_props){
-		for (const [key, value] of Object.entries(object_props)) {
-			if(key.startsWith("godot:node:")){
-				set_props[key.substring(11)] = value;
-			}
-		}
+    merge_properties(object_props, set_props){
+        for (const [key, value] of Object.entries(object_props)) {
+            if(key.startsWith("godot:node:")){
+                set_props[key.substring(11)] = value;
+            }
+        }
 
-		return set_props;
-	}
-	
-	meta_properties(object_props){
-		let results = {};
-		for (const [key, value] of Object.entries(object_props)) {
-			if(key.startsWith("godot:meta:")){
-				results[key.substring(11)] = value;
-			}
-		}
+        return set_props;
+    }
+    
+    meta_properties(object_props){
+        let results = {};
+        for (const [key, value] of Object.entries(object_props)) {
+            if(key.startsWith("godot:meta:")){
+                results[key.substring(11)] = value;
+            }
+        }
 
-		return results;
-	}
-	
+        return results;
+    }
+    
     writeToFile() {
         // noinspection JSUnresolvedVariable
         let file = new TextFile(this.fileName, TextFile.WriteOnly);
@@ -497,8 +497,8 @@ class GodotTilemapExporter {
      */
     getSceneTemplate() {
         const loadSteps = 2 + this.subResourceId;
-		const type = this.map.property("godot:type") || "Node2D";
-		const name = this.map.property("godot:name") || "Node2D";
+        const type = this.map.property("godot:type") || "Node2D";
+        const name = this.map.property("godot:name") || "Node2D";
         return `[gd_scene load_steps=${loadSteps} format=2]
 
 ${this.tilesetsString}
@@ -527,29 +527,29 @@ ${this.tileMapsString}
         const groups = splitCommaSeparated(layer.property("groups"));
         const zIndex = parseInt(layer.properties()['z_index'], 10);
         return stringifyNode(
-			{
-				name: tileMapName,
-				type: "TileMap",
-				parent: parent,
-				groups: groups
-			}, 
-			this.merge_properties(
-				layer.properties(),
-				{
-					visible: layer.visible,
-					modulate: `Color( 1, 1, 1, ${layer.opacity} )`,
-					position: `Vector2( ${layer.offset.x}, ${layer.offset.y} )`,
-					tile_set: `ExtResource( ${tilesetID} )`,
-          			cell_size: `Vector2( ${layer.map.tileWidth}, ${layer.map.tileHeight} )`,
-					cell_custom_transform: `Transform2D( 16, 0, 0, 16, 0, 0 )`,
-					format: 1,
-					mode: mode,
-					tile_data: `PoolIntArray( ${poolIntArrayString} )`,
-					z_index: typeof zIndex === 'number' && !isNaN(zIndex) ? zIndex : undefined
-				}
-			),
-			this.meta_properties(layer.properties())
-		);
+            {
+                name: tileMapName,
+                type: "TileMap",
+                parent: parent,
+                groups: groups
+            }, 
+            this.merge_properties(
+                layer.properties(),
+                {
+                    visible: layer.visible,
+                    modulate: `Color( 1, 1, 1, ${layer.opacity} )`,
+                    position: `Vector2( ${layer.offset.x}, ${layer.offset.y} )`,
+                    tile_set: `ExtResource( ${tilesetID} )`,
+                      cell_size: `Vector2( ${layer.map.tileWidth}, ${layer.map.tileHeight} )`,
+                    cell_custom_transform: `Transform2D( 16, 0, 0, 16, 0, 0 )`,
+                    format: 1,
+                    mode: mode,
+                    tile_data: `PoolIntArray( ${poolIntArrayString} )`,
+                    z_index: typeof zIndex === 'number' && !isNaN(zIndex) ? zIndex : undefined
+                }
+            ),
+            this.meta_properties(layer.properties())
+        );
     }
 
     mapLayerToTileset(layerName, tilesetID) {

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -536,6 +536,9 @@ ${this.tileMapsString}
 			this.merge_properties(
 				layer.properties(),
 				{
+					visible: layer.visible,
+					modulate: `Color( 1, 1, 1, ${layer.opacity} )`,
+					position: `Vector2( ${layer.offset.x}, ${layer.offset.y} )`,
 					tile_set: `ExtResource( ${tilesetID} )`,
           			cell_size: `Vector2( ${layer.map.tileWidth}, ${layer.map.tileHeight} )`,
 					cell_custom_transform: `Transform2D( 16, 0, 0, 16, 0, 0 )`,

--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -5,7 +5,7 @@ class GodotTilesetExporter {
     constructor(tileset, fileName) {
         this.tileset = tileset;
         this.fileName = fileName;
-		this.filePath = fileName.substring(0, fileName.lastIndexOf("/"));
+        this.filePath = fileName.substring(0, fileName.lastIndexOf("/"));
         // noinspection JSUnresolvedFunction
         this.projectRoot = getResPath(this.tileset.property("projectRoot"), fileName);
         this.spriteImagePath = this.tileset.image.replace(this.filePath, this.projectRoot);

--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -5,10 +5,9 @@ class GodotTilesetExporter {
     constructor(tileset, fileName) {
         this.tileset = tileset;
         this.fileName = fileName;
-        this.filePath = fileName.substring(0, fileName.lastIndexOf("/"));
         // noinspection JSUnresolvedFunction
         this.projectRoot = getResPath(this.tileset.property("projectRoot"), fileName);
-        this.spriteImagePath = this.tileset.image.replace(this.filePath, this.projectRoot);
+        this.spriteImagePath = this.tileset.image.replace(this.projectRoot, "");
         // Strip leading slashes to prevent invalid triple slashes in Godot res:// path:
         this.spriteImagePath = this.spriteImagePath.replace(/^\/+/, '');
         this.shapesResources = "";

--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -5,9 +5,10 @@ class GodotTilesetExporter {
     constructor(tileset, fileName) {
         this.tileset = tileset;
         this.fileName = fileName;
+		this.filePath = fileName.substring(0, fileName.lastIndexOf("/"));
         // noinspection JSUnresolvedFunction
         this.projectRoot = getResPath(this.tileset.property("projectRoot"), fileName);
-        this.spriteImagePath = this.tileset.image.replace(this.projectRoot, "");
+        this.spriteImagePath = this.tileset.image.replace(this.filePath, this.projectRoot);
         // Strip leading slashes to prevent invalid triple slashes in Godot res:// path:
         this.spriteImagePath = this.spriteImagePath.replace(/^\/+/, '');
         this.shapesResources = "";

--- a/utils.js
+++ b/utils.js
@@ -69,9 +69,9 @@ function splitCommaSeparated(str) {
  *         ```
  *          [node key="value"]
  *          content_key = AnyValue
-			__meta__ = {
-			"content_key" : AnyValue
-			}
+            __meta__ = {
+            "content_key" : AnyValue
+            }
  *         ```
  */
 function stringifyNode(nodeProperties, contentProperties = {}, metaProperties = {}) {
@@ -90,19 +90,19 @@ function stringifyNode(nodeProperties, contentProperties = {}, metaProperties = 
   }
   mProps = Object.entries(metaProperties)
   if(mProps.length > 0) {
-	str += '__meta__ = {\n';
-	var count = 0;
-	for(const [key, value] of mProps) {
-		if (count++ > 0){
-			str += ",\n";
-		}
-		var quoteValue = true;
-		if(typeof value === 'number' || typeof value === 'boolean') {
-			quoteValue = false;
-		}
-		str += this.stringifyKeyValue(key, value, true, quoteValue, true, ":");
-	}
-	str += '\n}\n';
+    str += '__meta__ = {\n';
+    var count = 0;
+    for(const [key, value] of mProps) {
+        if (count++ > 0){
+            str += ",\n";
+        }
+        var quoteValue = true;
+        if(typeof value === 'number' || typeof value === 'boolean') {
+            quoteValue = false;
+        }
+        str += this.stringifyKeyValue(key, value, true, quoteValue, true, ":");
+    }
+    str += '\n}\n';
   }
   return str;
 }
@@ -123,7 +123,7 @@ function stringifyKeyValue(key, value, quoteKey, quoteValue, spaces, separator =
     value = `"${value}"`;
   }
   if(quoteKey) {
-	key = `"${key}"`;
+    key = `"${key}"`;
   }
   if (!spaces) {
     return `${key}` + separator + `${value}`;


### PR DESCRIPTION
Added support for GroupLayer.
Added godot:type to Map and GroupLayer to specify Godot Node Type.
Added godot:name to Map to specify root object name.
Modifications to projectRoot so that it replaces the path with the projectRoot value.
Added godot:node: prefix for custom properties to allow godot node properties to be set within Tiled.
Added godot:meta: prefix for custom properties to allow godot meta properties to be set within Tiled.